### PR TITLE
Fix for text overflow in sidebar

### DIFF
--- a/src/components/list/ListItem.vue
+++ b/src/components/list/ListItem.vue
@@ -78,6 +78,7 @@ export default {
     font-size: 1rem
     font-weight: normal
     cursor: pointer
+    word-break: break-all
 
   .data-title::first-letter
     text-transform: capitalize

--- a/src/components/list/ListItem.vue
+++ b/src/components/list/ListItem.vue
@@ -126,6 +126,7 @@ export default {
 
     .data-item
       flex-basis: 20%
+      word-break: break-all
 
   /* ROUTER LINK STYLING */
 

--- a/src/components/list/ListItem.vue
+++ b/src/components/list/ListItem.vue
@@ -78,7 +78,7 @@ export default {
     font-size: 1rem
     font-weight: normal
     cursor: pointer
-    word-break: break-all
+    word-break: break-word
 
   .data-title::first-letter
     text-transform: capitalize
@@ -126,7 +126,7 @@ export default {
 
     .data-item
       flex-basis: 20%
-      word-break: break-all
+      word-break: break-word
 
   /* ROUTER LINK STYLING */
 


### PR DESCRIPTION
This fixes the text overflow in the sidebar for Firefox, Safari and Chrome.

- Added word-break: break-word to the appropriate classes
- Fixes #5
- Fixes #6 